### PR TITLE
changed logic to handle QPCR results file reupload for COVID-19 and D…

### DIFF
--- a/src/main/java/com/velox/sloan/cmo/workflows/covid19/QPCRResultsImporter.java
+++ b/src/main/java/com/velox/sloan/cmo/workflows/covid19/QPCRResultsImporter.java
@@ -71,10 +71,13 @@ public class QPCRResultsImporter extends DefaultGenericPlugin {
             //remove already attached records from task if already created. This is done to allow for the task to run again and not create duplicate rows of data;
             if (activeTask.getAttachedDataRecords(activeTask.getInputDataTypeName(), user).size()>0){
                 List<Long> recordIds = new ArrayList<>();
-                for (DataRecord rec: activeTask.getAttachedDataRecords(activeTask.getInputDataTypeName(), user)){
+                List<DataRecord> protocolRecords = activeTask.getAttachedDataRecords(activeTask.getInputDataTypeName(), user);
+                for (DataRecord rec: protocolRecords){
                     recordIds.add(rec.getRecordId());
                 }
                 activeTask.removeTaskAttachments(recordIds);
+                dataRecordManager.deleteDataRecords(protocolRecords, null, false, user);
+                logInfo(String.format("QPCR results file re-uploaded -> Deleted %s records attached to task created by previous QPCR results upload", activeTask.getInputDataTypeName()));
             }
             //entire data from file
             List<String> entireFile = utils.readDataFromCsvFile(clientCallback.readBytes(csvFilePath));

--- a/src/main/java/com/velox/sloan/cmo/workflows/covid19/UpdateSampleWellNumber.java
+++ b/src/main/java/com/velox/sloan/cmo/workflows/covid19/UpdateSampleWellNumber.java
@@ -96,7 +96,6 @@ public class UpdateSampleWellNumber extends DefaultGenericPlugin {
                count+=1;
            }
        }
-       clientCallback.displayInfo(wellIdToNumberMap.toString());
        return wellIdToNumberMap;
     }
 

--- a/src/main/java/com/velox/sloan/cmo/workflows/digitalpcr/DigitalPcrResultsParser.java
+++ b/src/main/java/com/velox/sloan/cmo/workflows/digitalpcr/DigitalPcrResultsParser.java
@@ -53,10 +53,13 @@ public class DigitalPcrResultsParser extends DefaultGenericPlugin {
             //remove already attached records from task if already created. This is done to allow for the task to run again;
             if (activeTask.getAttachedDataRecords(activeTask.getInputDataTypeName(), user).size()>0){
                 List<Long> recordIds = new ArrayList<>();
-                for (DataRecord rec: activeTask.getAttachedDataRecords(activeTask.getInputDataTypeName(), user)){
+                List<DataRecord> protocolRecords = activeTask.getAttachedDataRecords(activeTask.getInputDataTypeName(), user);
+                for (DataRecord rec: protocolRecords){
                     recordIds.add(rec.getRecordId());
                 }
                 activeTask.removeTaskAttachments(recordIds);
+                dataRecordManager.deleteDataRecords(protocolRecords, null, false, user);
+                logInfo(String.format("DDPCR results file re-uploaded -> Deleted %s records attached to task created by previous DDPCR results upload", activeTask.getInputDataTypeName()));
             }
             //read data from file and create new ddpcr assay results.
             for (String file : filesWithDigitalPcrRawData) {


### PR DESCRIPTION
…DPCR results file reupload for Digital PCR workflow to prevent creation of duplicate records.