### PR TITLE
Increasing number of requested reads from 1 -> 2 million per sample

### DIFF
--- a/src/main/java/com/velox/sloan/cmo/workflows/dlpplus/DlpSampleSplitterPoolMaker.java
+++ b/src/main/java/com/velox/sloan/cmo/workflows/dlpplus/DlpSampleSplitterPoolMaker.java
@@ -703,7 +703,7 @@ public class DlpSampleSplitterPoolMaker extends DefaultGenericPlugin {
         seqReqValues.put("OtherSampleId", otherSampleId);
         seqReqValues.put("AltId", otherSampleId);
         seqReqValues.put("SequencingRunType", seqRunTypeByQuadrant.get(quadrant));
-        seqReqValues.put("RequestedReads", numberOfSamples * 1.0); //this is a constant value 1M/sample defined value confirmed with Juan Li from innovation team
+        seqReqValues.put("RequestedReads", numberOfSamples * 2.0); //this is a constant value 1M/sample defined value confirmed with Juan Li from innovation team
         return seqReqValues;
     }
 


### PR DESCRIPTION
Requested 4/1 - The number of requested reads per live cell should be increased to 2 million