### PR TITLE
Bugfix/fm/sample qc lib report avg size bp

### DIFF
--- a/src/main/java/com/velox/sloan/cmo/workflows/qualitycontrol/QcReportGenerator.java
+++ b/src/main/java/com/velox/sloan/cmo/workflows/qualitycontrol/QcReportGenerator.java
@@ -31,8 +31,9 @@ public class QcReportGenerator extends DefaultGenericPlugin {
     private final String QC_TYPE_FOR_RIN = "bioanalyzer rna pico, bioanalyzer rna nano, tapestation rna screentape hisense sample table, tapestation rna screentape sample table";
     private final String QC_TYPE_FOR_A260280 = "nanodrop nano";
     private final String QC_TYPE_FOR_A260230 = "nanodrop nano";
-    private final String QC_TYPE_FOR_AVERAGE_BP_SIZE = "TapeStation Compact Peak Table, TapeStation Compact Pico Region Table, " +
-            "TapeStation D1000 Compact Region Table, TapeStation D1000 HiSense Compact Region Table, Bioanalyzer DNA High Sens Region Table";
+    private final String TAPESTATION_QC_FOR_AVERAGE_BP_SIZE = "TapeStation Compact Peak Table, TapeStation Compact Pico Region Table, " +
+            "TapeStation D1000 Compact Region Table, TapeStation D1000 HiSense Compact Region Table";
+    private final String BIOA_QC_FOR_AVERAGE_BP_SIZE = "Bioanalyzer DNA High Sens Region Table";
     private final List<String> DNA_SAMPLE_TYPES = Arrays.asList("cdna", "cfdna", "dna");
     private final List<String> RNA_SAMPLE_TYPES = Arrays.asList("rna");
     private final List<String> LIBRARY_SAMPLE_TYPES = Arrays.asList("dna library", "pooled library", "cdna library", "protein library");
@@ -547,7 +548,24 @@ public class QcReportGenerator extends DefaultGenericPlugin {
      * @throws ServerException
      */
     private Double getAverageLibrarySizeValue(String sampleId, List<DataRecord> qcRecords) {
-        List<DataRecord> qcRecordsWithAvgBpSizeForSample = getQcRecordsByQcType(sampleId, qcRecords, QC_TYPE_FOR_AVERAGE_BP_SIZE);
+        String[] stringListOfQcFiles = {"BioAnalyzer", "TapeStation"};
+        int selectedQcFile = 0;
+        try {
+            selectedQcFile = clientCallback.showOptionDialog("Selecting QC Average Size Bp",
+                    "Which QC file average size bp would you like to use: ", stringListOfQcFiles, 0);
+        }
+        catch (ServerException se) {
+            this.logError(String.valueOf(se.getStackTrace()));
+        }
+        List<DataRecord> qcRecordsWithAvgBpSizeForSample;
+        if (selectedQcFile == 0) {
+            qcRecordsWithAvgBpSizeForSample = getQcRecordsByQcType(sampleId, qcRecords, BIOA_QC_FOR_AVERAGE_BP_SIZE);
+        }
+        else {
+            qcRecordsWithAvgBpSizeForSample = getQcRecordsByQcType(sampleId, qcRecords, TAPESTATION_QC_FOR_AVERAGE_BP_SIZE);
+        }
+
+
         Double averageBasePairSize = 0.0;
         try {
             if (!qcRecordsWithAvgBpSizeForSample.isEmpty()) {

--- a/src/main/java/com/velox/sloan/cmo/workflows/qualitycontrol/QcReportGenerator.java
+++ b/src/main/java/com/velox/sloan/cmo/workflows/qualitycontrol/QcReportGenerator.java
@@ -29,8 +29,8 @@ public class QcReportGenerator extends DefaultGenericPlugin {
     private final String QC_TYPE_FOR_RQN = "fragment analyzer rna quality, fragment analyzer peak table";
     private final String QC_TYPE_FOR_DV200 = "fragment analyzer smear table, bioanalyzer rna pico, bioanalyzer rna nano, tapestation rna screentape hisense compactregion table, tapestation rna screentape compactregion table";
     private final String QC_TYPE_FOR_RIN = "bioanalyzer rna pico, bioanalyzer rna nano, tapestation rna screentape hisense sample table, tapestation rna screentape sample table";
-    private final String QC_TYPE_FOR_AVERAGE_BP_SIZE = "TapeStation Compact Peak Table, TapeStation Compact Pico Region Table, " +
-            "TapeStation D1000 Compact Region Table, TapeStation D1000 HiSense Compact Region Table, Bioanalyzer DNA High Sens Region Table";
+    private final String QC_TYPE_FOR_AVERAGE_BP_SIZE = "Bioanalyzer DNA High Sens Region Table, TapeStation Compact Peak Table, TapeStation Compact Pico Region Table, " +
+            "TapeStation D1000 Compact Region Table, TapeStation D1000 HiSense Compact Region Table";
     private final List<String> DNA_SAMPLE_TYPES = Arrays.asList("cdna", "cfdna", "dna");
     private final List<String> RNA_SAMPLE_TYPES = Arrays.asList("rna");
     private final List<String> LIBRARY_SAMPLE_TYPES = Arrays.asList("dna library", "pooled library", "cdna library", "protein library");

--- a/src/main/java/com/velox/sloan/cmo/workflows/qualitycontrol/QcReportGenerator.java
+++ b/src/main/java/com/velox/sloan/cmo/workflows/qualitycontrol/QcReportGenerator.java
@@ -547,24 +547,14 @@ public class QcReportGenerator extends DefaultGenericPlugin {
      * @throws RemoteException
      * @throws ServerException
      */
-    private Double getAverageLibrarySizeValue(String sampleId, List<DataRecord> qcRecords) {
-        String[] stringListOfQcFiles = {"BioAnalyzer", "TapeStation"};
-        int selectedQcFile = 0;
-        try {
-            selectedQcFile = clientCallback.showOptionDialog("Selecting QC Average Size Bp",
-                    "Which QC file average size bp would you like to use: ", stringListOfQcFiles, 0);
-        }
-        catch (ServerException se) {
-            this.logError(String.valueOf(se.getStackTrace()));
-        }
-        List<DataRecord> qcRecordsWithAvgBpSizeForSample;
+    private Double getAverageLibrarySizeValue(String sampleId, List<DataRecord> qcRecords, int selectedQcFile) {
+        List<DataRecord> qcRecordsWithAvgBpSizeForSample = new LinkedList<>();
         if (selectedQcFile == 0) {
             qcRecordsWithAvgBpSizeForSample = getQcRecordsByQcType(sampleId, qcRecords, BIOA_QC_FOR_AVERAGE_BP_SIZE);
         }
         else {
             qcRecordsWithAvgBpSizeForSample = getQcRecordsByQcType(sampleId, qcRecords, TAPESTATION_QC_FOR_AVERAGE_BP_SIZE);
         }
-
 
         Double averageBasePairSize = 0.0;
         try {
@@ -747,6 +737,15 @@ public class QcReportGenerator extends DefaultGenericPlugin {
      */
     private List<DataRecord> generateLibraryQcReportFieldValuesMap(List<DataRecord> samples, List<DataRecord> qcRecords, List<DataRecord> qcProtocolRecords) throws NotFound, RemoteException, ServerException {
         List<DataRecord> libraryQcRecords = new ArrayList<>();
+        String[] stringListOfQcFiles = {"BioAnalyzer", "TapeStation"};
+        int selectedQcFile = 0;
+        try {
+            selectedQcFile = clientCallback.showOptionDialog("Selecting QC Average Size Bp",
+                    "Which QC file average size bp would you like to use: ", stringListOfQcFiles, 0);
+        }
+        catch (ServerException se) {
+            this.logError(String.valueOf(se.getStackTrace()));
+        }
         for (DataRecord sample : samples) {
             Map<String, Object> qcRecord = new HashMap<>();
             try {
@@ -771,7 +770,7 @@ public class QcReportGenerator extends DefaultGenericPlugin {
                 }
                 qcRecord.put("TumorOrNormal", sample.getStringVal("TumorOrNormal", user));
                 qcRecord.put("Recipe", sample.getStringVal("Recipe", user));
-                Double averageBpSize = getAverageLibrarySizeValue(sampleId, qcRecords);
+                Double averageBpSize = getAverageLibrarySizeValue(sampleId, qcRecords, selectedQcFile);
                 String igoRecommendation = getIgoRecommendationValue(sampleId, qcProtocolRecords);
                 String comments = getQcCommentsValue(sampleId, qcProtocolRecords);
                 if (averageBpSize > 0) {


### PR DESCRIPTION
Sequencing team reported a [bug](https://mskcc.teamwork.com/app/tasks/28238863) from the Library/Pool QC workflow. When they upload both TapeStation and BioAnalyzer files the "Average Size Bp" should come from BioA instead of TapeStation. In QcReportGenerator plugin both TapeStation and BioA have been defined in the same pool and one overwrote the other average size bp values.
In this update we ask the LIMS user to select the qc file to read the average size bp value from (asks once for all samples).